### PR TITLE
Suppression des fichiers Json et des annotations Json + select sans jar

### DIFF
--- a/front-end/pom.xml
+++ b/front-end/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>xmart-city-commons</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>edu.ezip.ing1.pds.client</groupId>
+            <artifactId>xmart-select-client</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/front-end/src/main/java/edu/ezip/ing1/pds/front/RechercheReference.java
+++ b/front-end/src/main/java/edu/ezip/ing1/pds/front/RechercheReference.java
@@ -1,9 +1,14 @@
 package edu.ezip.ing1.pds.front;
 
+import edu.ezip.ing1.pds.client.SelectAllProductsClientRequest;
+
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.IOException;
 
-class RechercheReference{
+class RechercheReference implements ActionListener {
     //Boutons :
     JButton boutonConfirmer;
     String titre;
@@ -51,6 +56,7 @@ class RechercheReference{
         JTextField searchBar = new RoundJTextField(100);
         searchBar.setBounds(80, 150, 650, 40);
         boutonConfirmer = new JButton("Valider");
+        boutonConfirmer.addActionListener(this);
         boutonConfirmer.setBounds(360,230, 80, 30);
         secondPanel.add(searchBar);
         secondPanel.add(boutonConfirmer);
@@ -60,5 +66,16 @@ class RechercheReference{
         menuEmpreinteCarbone.setVisible(true);
 
         
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e){
+        if(e.getSource() == boutonConfirmer){
+            try {
+                SelectAllProductsClientRequest.launchSelectAllProducts();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
     }
 }

--- a/xmart-city-backend/select-1-product-request.json
+++ b/xmart-city-backend/select-1-product-request.json
@@ -1,7 +1,0 @@
-{
-  "request": {
-    "request_id": "6bed1b5e-5062-4084-a23f-8fa467efb7ca",
-    "request_order": "SELECT_ALL_PRODUCTS"
-  }
-}
-

--- a/xmart-city-backend/select-product-request.json
+++ b/xmart-city-backend/select-product-request.json
@@ -1,9 +1,0 @@
-{
-  "request": {
-    "request_id": "6bed1b5e-5062-4084-a23f-8fa467efb7ca",
-    "request_order": "SELECT_ALL_PRODUCTS",
-    "request_body": {
-      "body_attr": "No body"
-    }
-  }
-}

--- a/xmart-city-business-dto/src/main/java/edu/ezip/ing1/pds/business/dto/Produit.java
+++ b/xmart-city-business-dto/src/main/java/edu/ezip/ing1/pds/business/dto/Produit.java
@@ -1,15 +1,10 @@
 package edu.ezip.ing1.pds.business.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
-
 import java.lang.reflect.Field;
-import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-@JsonRootName(value = "produit")
 public class Produit {
     private int idProduit;
     private int idEmplacement;
@@ -61,7 +56,6 @@ public class Produit {
         return idProduit;
     }
 
-    @JsonProperty("produit_idProduit")
     public void setIdProduit(int idProduit) {
         this.idProduit = idProduit;
     }
@@ -70,82 +64,70 @@ public class Produit {
         return idEmplacement;
     }
 
-    @JsonProperty("produit_idEmplacement")
     public void setIdEmplacement(int idEmplacement){this.idEmplacement = idEmplacement;}
 
     public String getPaysDepart() {
         return paysDepart;
     }
 
-    @JsonProperty("produit_paysDepart")
     public void setPaysDepart(String paysDepart){this.paysDepart = paysDepart;}
 
     public String getPaysArrivee() {
         return paysArrivee;
     }
 
-    @JsonProperty("produit_paysArrivee")
     public void setPaysArrivee(String paysArrivee){this.paysArrivee = paysArrivee;}
 
     public String getCouleur() {
         return couleur;
     }
 
-    @JsonProperty("produit_couleur")
     public void setCouleur(String couleur){this.couleur = couleur;}
 
     public String getTaille() {
         return taille;
     }
 
-    @JsonProperty("produit_taille")
     public void setTaille(String taille){this.taille = taille;}
 
     public int getReference() {
         return reference;
     }
 
-    @JsonProperty("produit_reference")
     public void setReference(int reference){this.reference = reference;}
 
     public String getScore() {
         return score;
     }
 
-    @JsonProperty("produit_score")
     public void setScore(String score) {this.score = score;}
 
     public String getGenre() {
         return genre;
     }
 
-    @JsonProperty("produit_genre")
     public void setGenre(String genre){this.genre = genre;}
 
     public float getEmpreinte() {
         return empreinte;
     }
 
-    @JsonProperty("produit_empreinte")
     public void setEmpreinte(float empreinte){this.empreinte = empreinte;}
 
     public int getIdMagasin() {
         return idMagasin;
     }
 
-    @JsonProperty("produit_idMagasin")
     public void setIdMagasin(int idMagasin){this.idMagasin = idMagasin;}
 
     public int getIdMarque(){return idMarque;}
 
-    @JsonProperty("produit_idMarque")
     public void setIdMarque(int idMarque){this.idMarque = idMarque;}
 
     public String getNomProduit() {
         return nomProduit;
     }
 
-    @JsonProperty("produit_nomProduit")
     public void setNomProduit(String nomProduit){this.nomProduit = nomProduit;}
 
 

--- a/xmart-city-business-dto/src/main/java/edu/ezip/ing1/pds/business/dto/Produits.java
+++ b/xmart-city-business-dto/src/main/java/edu/ezip/ing1/pds/business/dto/Produits.java
@@ -1,17 +1,10 @@
 package edu.ezip.ing1.pds.business.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
-
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-@JsonRootName(value = "produits")
 public class Produits {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @JsonProperty("produits")
     private Set<Produit> produits = new LinkedHashSet<>();
 
     public Set<Produit> getProduits() {

--- a/xmart-city-client-commons/src/main/java/edu/ezip/ing1/pds/client/commons/ClientRequest.java
+++ b/xmart-city-client-commons/src/main/java/edu/ezip/ing1/pds/client/commons/ClientRequest.java
@@ -18,9 +18,6 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
-
-//Les classes InsertClientRequest et SelectClientRequest étendent cette classe.
-
 public abstract class ClientRequest<N,S> implements Runnable {
     private final Socket socket = new Socket();
     private final Thread self;

--- a/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Request.java
+++ b/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Request.java
@@ -1,26 +1,19 @@
 package edu.ezip.ing1.pds.commons;
 
-import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
-@JsonRootName(value = "request")
 public class Request {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String requestId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String requestOrder;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String requestBody;
 
-    @JsonProperty("request_order")
     public void setRequestOrder(String requestOrder) {
         this.requestOrder = requestOrder;
     }
 
-    @JsonSetter("request_body")
     public void setRequestBody(JsonNode requestBody) {
         this.requestBody = requestBody.toString();
     }
@@ -29,7 +22,6 @@ public class Request {
         this.requestBody = requestBody;
     }
 
-    @JsonProperty("request_id")
     public void setRequestId(String requestId) {
         this.requestId = requestId;
     }
@@ -42,7 +34,6 @@ public class Request {
         return requestOrder;
     }
 
-    @JsonRawValue
     public String getRequestBody() {
         return requestBody;
     }

--- a/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
+++ b/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
@@ -8,7 +8,7 @@ public class Response {
     public String responseBody;
 
     public Response() {
-
+c
     }
     public Response(String requestId, String responseBody) {
         this.requestId = requestId;

--- a/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
+++ b/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
@@ -3,7 +3,6 @@ package edu.ezip.ing1.pds.commons;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
-@JsonRootName(value = "response")
 public class Response {
     public String requestId;
 
@@ -17,18 +16,14 @@ public class Response {
         this.responseBody = responseBody;
     }
 
-    @JsonProperty("request_id")
     public String getRequestId() {
         return requestId;
     }
 
-    @JsonProperty("request_id")
     public void setRequestId(String requestId) {
         this.requestId = requestId;
     }
 
-    @JsonProperty("response_body")
-    @JsonRawValue
     public String getResponseBody() {
         return responseBody;
     }
@@ -37,7 +32,6 @@ public class Response {
         this.responseBody = responseBody;
     }
 
-    @JsonSetter("response_body")
     public void setBody(JsonNode responseBody) {
         this.responseBody = responseBody.toString();
     }

--- a/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
+++ b/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
@@ -1,6 +1,5 @@
 package edu.ezip.ing1.pds.commons;
 
-import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class Response {

--- a/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
+++ b/xmart-city-commons/src/main/java/edu/ezip/ing1/pds/commons/Response.java
@@ -8,7 +8,7 @@ public class Response {
     public String responseBody;
 
     public Response() {
-c
+
     }
     public Response(String requestId, String responseBody) {
         this.requestId = requestId;

--- a/xmart-select-client/src/main/java/edu/ezip/ing1/pds/client/MainSelectClient.java
+++ b/xmart-select-client/src/main/java/edu/ezip/ing1/pds/client/MainSelectClient.java
@@ -47,37 +47,11 @@ public class MainSelectClient {
         objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
         final byte []  requestBytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(request);
         LoggingUtils.logDataMultiLine(logger, Level.TRACE, requestBytes);
-//        final SelectAllStudentsClientRequest clientRequest = new SelectAllStudentsClientRequest(
-//                                                                    networkConfig,
-//                                                                    birthdate++, request, null, requestBytes);
                 final SelectAllProductsClientRequest clientRequest = new SelectAllProductsClientRequest(
                                                                     networkConfig,
                                                                     birthdate++, request, null, requestBytes);
         clientRequests.push(clientRequest);
 
-//        while (!clientRequests.isEmpty()) {
-//            final ClientRequest joinedClientRequest = clientRequests.pop();
-//            joinedClientRequest.join();
-//            logger.debug("Thread {} complete.", joinedClientRequest.getThreadName());
-//            final Students students = (Students) joinedClientRequest.getResult();
-//            final AsciiTable asciiTable = new AsciiTable();
-//            for (final Student student : students.getStudents()) {
-//                asciiTable.addRule();
-//                asciiTable.addRow(student.getFirstname(), student.getName(), student.getGroup());
-//            }
-//            asciiTable.addRule();
-//            logger.debug("\n{}\n", asciiTable.render());
-//
-////            String resp = "";
-////            for (final Student student : students.getStudents()) {
-//////                asciiTable.addRule();
-//////                asciiTable.addRow(student.getFirstname(), student.getName(), student.getGroup());
-////                resp += student.getFirstname() + " ";
-////                resp += student.getName() + " ";
-////                resp += student.getGroup() + "\n ";
-////            }
-////            System.out.println(resp);
-//        }
 
         while (!clientRequests.isEmpty()) {
             final ClientRequest joinedClientRequest = clientRequests.pop();
@@ -91,16 +65,6 @@ public class MainSelectClient {
             }
             asciiTable.addRule();
             logger.debug("\n{}\n", asciiTable.render());
-
-//            String resp = "";
-//            for (final Student student : students.getStudents()) {
-////                asciiTable.addRule();
-////                asciiTable.addRow(student.getFirstname(), student.getName(), student.getGroup());
-//                resp += student.getFirstname() + " ";
-//                resp += student.getName() + " ";
-//                resp += student.getGroup() + "\n ";
-//            }
-//            System.out.println(resp);
         }
     }
 }

--- a/xmart-select-client/src/main/java/edu/ezip/ing1/pds/client/SelectAllProductsClientRequest.java
+++ b/xmart-select-client/src/main/java/edu/ezip/ing1/pds/client/SelectAllProductsClientRequest.java
@@ -1,14 +1,35 @@
 package edu.ezip.ing1.pds.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import de.vandermeer.asciitable.AsciiTable;
+import edu.ezip.commons.LoggingUtils;
+import edu.ezip.ing1.pds.business.dto.Produit;
 import edu.ezip.ing1.pds.business.dto.Produits;
 import edu.ezip.ing1.pds.client.commons.ClientRequest;
+import edu.ezip.ing1.pds.client.commons.ConfigLoader;
 import edu.ezip.ing1.pds.client.commons.NetworkConfig;
 import edu.ezip.ing1.pds.commons.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.UUID;
 
 public class SelectAllProductsClientRequest extends ClientRequest<Object, Produits> {
+
+    //Attributs pour lancer la requête.
+    private final static String LoggingLabel = "S e l e c t - P r o d u c t";
+    private final static Logger logger = LoggerFactory.getLogger(LoggingLabel);
+    private final static String studentsToBeInserted = "students-to-be-inserted.yaml";
+    private final static String networkConfigFile = "network.yaml";
+    private static final String threadName = "inserter-client";
+    private static final String requestOrder = "SELECT_ALL_PRODUCTS";
+    private static final Deque<ClientRequest> clientRequests = new ArrayDeque<ClientRequest>();
+
 
     public SelectAllProductsClientRequest(
             NetworkConfig networkConfig, int myBirthDate, Request request, Object info, byte[] bytes)
@@ -22,4 +43,44 @@ public class SelectAllProductsClientRequest extends ClientRequest<Object, Produi
         final Produits produits = mapper.readValue(body, Produits.class);
         return produits;
     }
+
+
+    //==================================
+    //Fonction pour lancer la requête (à la place du main) :
+    public static void launchSelectAllProducts() throws IOException, InterruptedException{
+        final NetworkConfig networkConfig = ConfigLoader.loadConfig(NetworkConfig.class, networkConfigFile);
+        logger.debug("Load Network config file : {}", networkConfig.toString());
+
+        int birthdate = 0;
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final String requestId = UUID.randomUUID().toString();
+        final Request request = new Request();
+        request.setRequestId(requestId);
+        request.setRequestOrder(requestOrder);
+        objectMapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+        final byte []  requestBytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(request);
+        LoggingUtils.logDataMultiLine(logger, Level.TRACE, requestBytes);
+        final SelectAllProductsClientRequest clientRequest = new SelectAllProductsClientRequest(
+                networkConfig,
+                birthdate++, request, null, requestBytes);
+        clientRequests.push(clientRequest);
+
+
+        while (!clientRequests.isEmpty()) {
+            final ClientRequest joinedClientRequest = clientRequests.pop();
+            joinedClientRequest.join();
+            logger.debug("Thread {} complete.", joinedClientRequest.getThreadName());
+            final Produits produits = (Produits) joinedClientRequest.getResult();
+            final AsciiTable asciiTable = new AsciiTable();
+            for (final Produit produit : produits.getProduits()) {
+                asciiTable.addRule();
+                asciiTable.addRow(produit.getIdProduit(), produit.getIdEmplacement(), produit.getPaysDepart(), produit.getPaysArrivee(), produit.getCouleur(), produit.getTaille(), produit.getReference(), produit.getScore(), produit.getGenre(), produit.getEmpreinte(), produit.getIdMagasin(), produit.getIdMarque(), produit.getNomProduit());
+            }
+            asciiTable.addRule();
+            logger.debug("\n{}\n", asciiTable.render());
+        }
+    }
+
+
+
 }


### PR DESCRIPTION
Ajout d'une fonction statique dans SelectAllProductClientRequest qui permet de lancer un Select en base sans avoir à lancer de jar.  Test dans le front end dans la classe RechercheReference : les données de la base apparaissent dans la console run à l'appui sur "valider". Suppression des fichiers Json et des annotations Json.

Tout testé manuellement.

[Concernant les SELECT uniquement, pas encore touché aux inserts]